### PR TITLE
Deprecated buggy function: scroll(to view: UIView, animated: Bool)

### DIFF
--- a/StackScrollView/StackScrollView.swift
+++ b/StackScrollView/StackScrollView.swift
@@ -242,6 +242,8 @@ open class StackScrollView: UICollectionView, UICollectionViewDataSource, UIColl
     }
   }
 
+  /// This method might fail if the view is out of bounds. Use `func scroll(to view: UIView, at position: UICollectionView.ScrollPosition, animated: Bool)` instead
+  @available(*, deprecated, message: "Use `scroll(to view: UIView, at position: UICollectionView.ScrollPosition, animated: Bool)` instead")
   open func scroll(to view: UIView, animated: Bool) {
     
     let targetRect = view.convert(view.bounds, to: self)


### PR DESCRIPTION
The function does not work as expected. If the target view is out of bounds, it might not be present in the view hierarchy, and the scroll will fail. 
Since ` open func scroll(to view: UIView, at position: UICollectionView.ScrollPosition, animated: Bool) {` is a good replacement, I think we can remove it entirely. I only deprecated it this time to ease the transition. 